### PR TITLE
fix export and import scenes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,8 @@
-import { Boot } from './scenes/Boot';
-import { Game } from './scenes/Game';
-import { GameOver } from './scenes/GameOver';
-import { MainMenu } from './scenes/MainMenu';
-import { Preloader } from './scenes/Preloader';
+import Boot from './scenes/Boot';
+import Game from './scenes/Game';
+import GameOver from './scenes/GameOver';
+import MainMenu from './scenes/MainMenu';
+import Preloader from './scenes/Preloader';
 
 //  Find out more information about the Game Config at:
 //  https://newdocs.phaser.io/docs/3.70.0/Phaser.Types.Core.GameConfig

--- a/src/scenes/Boot.js
+++ b/src/scenes/Boot.js
@@ -1,7 +1,5 @@
-import { Scene } from 'phaser';
 
-export class Boot extends Scene
-{
+export default class Boot extends Phaser.Scene {
     constructor ()
     {
         super('Boot');

--- a/src/scenes/Boot.js
+++ b/src/scenes/Boot.js
@@ -1,4 +1,4 @@
-
+import Phaser from "phaser";
 export default class Boot extends Phaser.Scene {
     constructor ()
     {

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -1,3 +1,5 @@
+import Phaser from "phaser";
+
 export default class Game extends Phaser.Scene {
   constructor() {
     super("Game");

--- a/src/scenes/GameOver.js
+++ b/src/scenes/GameOver.js
@@ -1,7 +1,5 @@
-import { Scene } from 'phaser';
 
-export class GameOver extends Scene
-{
+export default class GameOver extends Phaser.Scene {
     constructor ()
     {
         super('GameOver');

--- a/src/scenes/GameOver.js
+++ b/src/scenes/GameOver.js
@@ -1,3 +1,4 @@
+import Phaser from "phaser";
 
 export default class GameOver extends Phaser.Scene {
     constructor ()

--- a/src/scenes/MainMenu.js
+++ b/src/scenes/MainMenu.js
@@ -1,7 +1,5 @@
-import { Scene } from 'phaser';
 
-export class MainMenu extends Scene
-{
+export default class MainMenu extends Phaser.Scene {
     constructor ()
     {
         super('MainMenu');

--- a/src/scenes/MainMenu.js
+++ b/src/scenes/MainMenu.js
@@ -1,3 +1,4 @@
+import Phaser from "phaser";
 
 export default class MainMenu extends Phaser.Scene {
     constructor ()

--- a/src/scenes/Preloader.js
+++ b/src/scenes/Preloader.js
@@ -1,7 +1,6 @@
-import { Scene } from 'phaser';
 
-export class Preloader extends Scene
-{
+
+export default class Preloader extends Phaser.Scene {
     constructor ()
     {
         super('Preloader');

--- a/src/scenes/Preloader.js
+++ b/src/scenes/Preloader.js
@@ -1,4 +1,4 @@
-
+import Phaser from "phaser";
 
 export default class Preloader extends Phaser.Scene {
     constructor ()


### PR DESCRIPTION
Este pr consistió solucionar la duda planteada en discord:

- Se corrigió **exportación** de cada escena. 
Antes: 
```
import { Scene } from 'phaser';

export class NombreScena extends Scene
```
Ahora: 
`export default class NombreScena extends Phaser.Scene `


- Se corrigió la **importación** de las escenas:
Antes:  `import { NombreScena } from './scenes/NombreScena'`;
Ahora: `import NombreScena from './scenes/NombreScena ';`

